### PR TITLE
added PKGBUILD file

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -1,0 +1,33 @@
+pkgname=latex-listings-rust-git
+_gitpkgname="${pkgname%-git}"
+_gitpkgname="${_gitpkgname#latex-}"
+pkgver=VERSION
+pkgrel=1
+pkgdesc="A Rust language and style specification for the LaTeX-package listings"
+arch=('any')
+url="https://github.com/denki/listings-rust"
+license=('BSD')
+groups=()
+depends=('texlive-core')
+makedepends=('git')
+provides=("${pkgname%-git}")
+conflicts=("${pkgname%-git}")
+replaces=()
+backup=()
+options=()
+install=
+source=("git+${url}.git")
+noextract=()
+md5sums=('SKIP')
+
+pkgver() {
+	cd "${_gitpkgname}"
+	printf "r%s.%s" "$(git rev-list --count HEAD)" "$(git rev-parse --short HEAD)"
+}
+
+package() {
+	cd "$srcdir/${_gitpkgname}"
+	install -m 755 -d $pkgdir/usr/share/texmf-dist/tex/latex/listings-rust
+	install -m 644 listings-rust.sty $pkgdir/usr/share/texmf-dist/tex/latex/listings-rust
+}
+


### PR DESCRIPTION
... which enables the latex package to be installed in archlinux with
```
git clone https://github.com/denki/listings-rust.git
cd listings-rust
makepkg -si
```